### PR TITLE
SECCOMP-27056 Updating golang libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.22
-ARG ALPINE_VERSION=3.16
+ARG ALPINE_VERSION=3.19
 ARG XX_VERSION=1.1.1
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.18
+ARG GO_VERSION=1.22
 ARG ALPINE_VERSION=3.16
 ARG XX_VERSION=1.1.1
 

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.6.1
 	github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50
-	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
+	golang.org/x/crypto v0.22.0
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c
 	google.golang.org/api v0.30.0
 	google.golang.org/cloud v0.0.0-20151119220103-975617b05ea8
@@ -66,11 +66,11 @@ require (
 	github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43 // indirect
 	github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f // indirect
 	go.opencensus.io v0.22.4 // indirect
-	golang.org/x/net v0.4.0 // indirect; updated for CVE-2022-27664, CVE-2022-41717
+	golang.org/x/net v0.24.0 // indirect; updated for CVE-2022-27664, CVE-2022-41717
 	golang.org/x/sys v0.3.0 // indirect
 	golang.org/x/text v0.5.0 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20200825200019-8632dd797987 // indirect
 	google.golang.org/grpc v1.31.0 // indirect
-	google.golang.org/protobuf v1.26.0 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 )


### PR DESCRIPTION
What: Updating golang libs
Why: Findings on this [scan](https://prodmon.app.sysdig.com/secure/#/vulnerabilities/results/17aeeeea981f54398593891098bc9800/vulnerabilities)
